### PR TITLE
Potential fix for code scanning alert no. 4: Clear-text logging of sensitive information

### DIFF
--- a/gallery-service/main.go
+++ b/gallery-service/main.go
@@ -641,7 +641,7 @@ func authnMiddleware(next http.Handler) http.Handler {
 
 		if strings.HasPrefix(authz, "Bearer") {
 			tokenString := strings.TrimSpace(strings.TrimPrefix(authz, "Bearer"))
-			log.Printf("AuthN: Received bearer token %s", tokenString)
+			log.Printf("AuthN: Received bearer token")
 			token, err := jwt.ParseWithClaims(tokenString, &OctoClaims{}, func(token *jwt.Token) (interface{}, error) {
 				// Don't forget to validate the alg is what you expect:
 				//if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
@@ -660,7 +660,7 @@ func authnMiddleware(next http.Handler) http.Handler {
 			
 			
 			if claims, ok := token.Claims.(*OctoClaims); ok && token.Valid {
-				log.Printf("AuthN: Received valid token %s", authz)
+				log.Printf("AuthN: Received valid token")
 
 				log.Printf("AuthN: Adding %s %s", GitHubLoginHeader, claims.Profile.Login)
 				r.Header.Add(GitHubLoginHeader.String(), claims.Profile.Login)


### PR DESCRIPTION
Potential fix for [https://github.com/HoneywellClientOrg/revanthkumar-HGAS-Repo/security/code-scanning/4](https://github.com/HoneywellClientOrg/revanthkumar-HGAS-Repo/security/code-scanning/4)

To fix this without changing behavior, keep authentication logic unchanged but stop logging sensitive token content.

Best fix in this snippet:
- In `gallery-service/main.go`, inside `authnMiddleware`:
  - Replace the log at line 644 so it does **not** include `tokenString`.
  - Replace the log at line 663 so it does **not** include `authz`.
- Keep informational logging, but only log non-sensitive status messages (e.g., “received bearer token”, “received valid token”).

This preserves functionality (token parsing/validation and header propagation) while eliminating cleartext logging of credentials.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
