### PR TITLE
Potential fix for code scanning alert no. 5: Disabled Spring CSRF protection

### DIFF
--- a/storage-service/src/main/java/com/github/advancedsecurity/storageservice/WebSecurityConfig.java
+++ b/storage-service/src/main/java/com/github/advancedsecurity/storageservice/WebSecurityConfig.java
@@ -44,7 +44,6 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 		BearerAuthenticationFilter filter = new BearerAuthenticationFilter(authenticationManager(), this.antPattern);
 		filter.setAuthenticationSuccessHandler(jwtAuthenticationSuccessHandler);
 		http.cors().and()
-			 .csrf().disable()
 			 .authorizeRequests().antMatchers(this.antPattern).authenticated().and()
 			 .addFilterBefore(filter, UsernamePasswordAuthenticationFilter.class)
 			 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);


### PR DESCRIPTION
Potential fix for [https://github.com/HoneywellClientOrg/revanthkumar-HGAS-Repo/security/code-scanning/5](https://github.com/HoneywellClientOrg/revanthkumar-HGAS-Repo/security/code-scanning/5)

To fix this without changing the app’s authentication flow, remove the explicit CSRF disable from the `HttpSecurity` chain so Spring Security’s default CSRF protection remains enabled.

Best single change in:
- `storage-service/src/main/java/com/github/advancedsecurity/storageservice/WebSecurityConfig.java`
- Inside `configure(HttpSecurity http)`, replace:
  - `http.cors().and().csrf().disable()...`
  - with `http.cors().and()...` continuing the existing chain.

No new methods, classes, or dependencies are required. Existing imports can remain unchanged (even if one becomes unused).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
